### PR TITLE
Added numba to the environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy
 numpy
 matplotlib
-
+numba


### PR DESCRIPTION
Binder throws "No module named 'numba' " when executing Challenge 6. 